### PR TITLE
Improve UI styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,18 @@
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  background-color: #f5f7fa;
 }
+
+.card {
+  border: none;
+  border-radius: 0.5rem;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+}
+
 .tags {
   margin-left: 1em;
+}
+
+.badge {
+  font-size: 0.85em;
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,10 +4,11 @@
   <meta charset="UTF-8">
   <title>論文紹介アプリ</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body class="container py-4">
-  <h1 class="mb-4">論文紹介</h1>
+  <h1 class="mb-4 fw-bold">論文紹介</h1>
   <form method="get" class="mb-3 row g-2">
     <div class="col-sm-8">
       <input type="text" class="form-control" name="q" placeholder="検索..." value="<%= query %>">
@@ -16,17 +17,29 @@
       <button type="submit" class="btn btn-primary w-100">検索</button>
     </div>
   </form>
-  <ul class="list-group">
+  <div class="row">
   <% if (papers.length) { %>
     <% papers.forEach(paper => { %>
-      <li class="list-group-item d-flex justify-content-between align-items-center">
-        <a href="/paper/<%= paper.id %>"><%= paper.title %></a>
-        <span class="text-muted"><%= paper.tags.join(', ') %></span>
-      </li>
+      <div class="col-md-6 mb-4">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body">
+            <h5 class="card-title mb-2">
+              <a href="/paper/<%= paper.id %>" class="stretched-link text-decoration-none text-dark">
+                <%= paper.title %>
+              </a>
+            </h5>
+            <div>
+              <% paper.tags.forEach(tag => { %>
+                <span class="badge bg-secondary me-1"><%= tag %></span>
+              <% }) %>
+            </div>
+          </div>
+        </div>
+      </div>
     <% }) %>
   <% } else { %>
-    <li class="list-group-item">論文が見つかりませんでした。</li>
+    <p>論文が見つかりませんでした。</p>
   <% } %>
-  </ul>
+  </div>
 </body>
 </html>

--- a/views/paper.ejs
+++ b/views/paper.ejs
@@ -4,27 +4,32 @@
   <meta charset="UTF-8">
   <title><%= paper.title %></title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="container py-4">
-  <h1 class="mb-3"><%= paper.title %></h1>
+  <h1 class="mb-3 fw-bold"><%= paper.title %></h1>
   <p class="text-muted">著者: <%= paper.authors.join(', ') %> (<%= paper.year %>)</p>
 
-  <h2>PICO</h2>
-  <ul>
-    <li>P: <%= paper.pico.population %></li>
-    <li>I: <%= paper.pico.intervention %></li>
-    <li>C: <%= paper.pico.comparison %></li>
-    <li>O: <%= paper.pico.outcome %></li>
+  <h2 class="mt-4">PICO</h2>
+  <ul class="list-group list-group-flush mb-3">
+    <li class="list-group-item">P: <%= paper.pico.population %></li>
+    <li class="list-group-item">I: <%= paper.pico.intervention %></li>
+    <li class="list-group-item">C: <%= paper.pico.comparison %></li>
+    <li class="list-group-item">O: <%= paper.pico.outcome %></li>
   </ul>
 
-  <p><strong>組み入れ基準:</strong> <%= paper.inclusion %></p>
-  <p><strong>除外基準:</strong> <%= paper.exclusion %></p>
+  <div class="mb-3">
+    <strong>組み入れ基準:</strong> <%= paper.inclusion %>
+  </div>
+  <div class="mb-4">
+    <strong>除外基準:</strong> <%= paper.exclusion %>
+  </div>
 
   <h2>結果</h2>
   <p><%= paper.results %></p>
-  <canvas id="resultChart"></canvas>
+  <canvas id="resultChart" class="mb-4"></canvas>
 
   <h2>考察</h2>
   <p><%= paper.discussion %></p>
@@ -32,7 +37,11 @@
   <h2>批判的吟味</h2>
   <p><%= paper.critique %></p>
 
-  <p>タグ: <%= paper.tags.join(', ') %></p>
+  <div class="mt-4">
+    <% paper.tags.forEach(tag => { %>
+      <span class="badge bg-secondary me-1"><%= tag %></span>
+    <% }) %>
+  </div>
 
   <p><a href="/" class="btn btn-secondary mt-3">一覧へ戻る</a></p>
 


### PR DESCRIPTION
## Summary
- modernize style with card shadows, badges, and Noto Sans font
- update index page layout with card grid
- refresh paper detail page style

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f0c7950fc832c96df3cfbb4f2f217